### PR TITLE
fix: storage API disabled awareness

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -563,20 +563,29 @@ where
                             let value = match resp {
                                 Ok(value) => value,
                                 Err(err) => {
-                                    // notify all listeners
-                                    let err = Arc::new(err);
-                                    if let Some(listeners) =
-                                        pin.storage_requests.remove(&(addr, idx))
-                                    {
-                                        listeners.into_iter().for_each(|l| {
-                                            let _ = l.send(Err(DatabaseError::GetStorage(
-                                                addr,
-                                                idx,
-                                                Arc::clone(&err),
-                                            )));
-                                        })
+                                    let err_str = err.to_string();
+                                    // If storage APIs are disabled, fall back to default zero value
+                                    // This allows scripts to work with nodes that have storage APIs
+                                    // disabled
+                                    if err_str.contains("Storage APIs are disabled") {
+                                        warn!(target: "backendhandler", %addr, %idx, "Storage APIs disabled, using default zero value");
+                                        FlaggedStorage::default()
+                                    } else {
+                                        // notify all listeners with the actual error
+                                        let err = Arc::new(err);
+                                        if let Some(listeners) =
+                                            pin.storage_requests.remove(&(addr, idx))
+                                        {
+                                            listeners.into_iter().for_each(|l| {
+                                                let _ = l.send(Err(DatabaseError::GetStorage(
+                                                    addr,
+                                                    idx,
+                                                    Arc::clone(&err),
+                                                )));
+                                            })
+                                        }
+                                        continue;
                                     }
-                                    continue;
                                 }
                             };
 


### PR DESCRIPTION
Currently, `SharedBackend` fails when the RPC node has storage APIs disabled, blocking script execution.

This PR introduces, in `src/backend.rs`, detecting `"Storage APIs are disabled"` errors and return `FlaggedStorage::default()` instead of propagating the error.

## Changes

- `backend.rs` lines 565-589: Added error string check in `ProviderRequest::Storage` handler
- Logs a warning when fallback occurs
- Other storage errors still propagate normally
