### PR TITLE
fix: cargo patch dependencies (upstream alloy broke semver)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-seismic-prelude = "0.0.1"
 alloy-chains = { version = "0.2", default-features = false, features = ["serde"] }
 alloy-consensus = { version = "1.0.25", default-features = false }
 alloy-hardforks = { version = "0.2.13", default-features = false }
@@ -49,29 +48,36 @@ tracing = "0.1"
 
 url = "2"
 
+# seismic-prelude is only used for a few things, yet it brings with it a huge dependency chain including enclave,
+# which is why we need to patch enclave below.
+# TODO(samlaf): We might want to only depend on the exact dependency, or else add feature flags to seismic-prelude.
+seismic-prelude = "0.0.1"
+
 [dev-dependencies]
 alloy-rpc-client = "1.0.25"
 tiny_http = "0.12"
 
 [patch.crates-io]
-# seismic-foundry
-seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "12bf284cc6cec2bb49ce24879200dcff16857aa9" }
-
 # seismic-alloy-core
-alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
-alloy-json-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
-alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
-alloy-sol-macro = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
-alloy-sol-macro-expander = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
-alloy-sol-macro-input = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
-alloy-sol-types = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
-alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "33e302d06f56bb4dda85359005af7e302f48272f" }
+alloy-dyn-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
+alloy-json-abi = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
+alloy-primitives = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
+alloy-sol-macro = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
+alloy-sol-macro-expander = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
+alloy-sol-macro-input = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
+alloy-sol-types = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
+alloy-sol-type-parser = { git = "https://github.com/SeismicSystems/seismic-alloy-core.git", rev = "fa63d477d6aa01e7203b677632c31cb3eba00640" }
 
-alloy-trie = { git = "https://github.com/SeismicSystems/seismic-trie.git", rev = "d8425918ced1d62043c3a64b382d6fa1d8c25518" }
+# This is needed because alloy-consensus depends on this crate for some proc macro, and the versions aren't locked together.
+# seismic-prelude -> alloy-consensus (=1.1.0 in alloy's Cargo.toml) -> alloy-tx-macros (floating version which didnt respect semver)
+alloy-tx-macros = { git = "https://github.com/alloy-rs/alloy", tag = "v1.1.0" }
 
 # seismic-revm
-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5df78108a382e66420ad9b815d3f41b5e35f3cc8" }
-seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "5df78108a382e66420ad9b815d3f41b5e35f3cc8" }
+revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e2ab654c4f8bc5e8f98d15ffe7a9880ace2f8a56" }
+seismic-revm = { git = "https://github.com/SeismicSystems/seismic-revm.git", rev = "e2ab654c4f8bc5e8f98d15ffe7a9880ace2f8a56" }
 
 # seismic-alloy
-seismic-prelude = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "84dae78acc18792399b83b188e1523d282528427" }
+seismic-prelude = { git = "https://github.com/SeismicSystems/seismic-alloy.git", rev = "ebc3628c9e384b1db5a41044dd32756b3e79aacb" }
+
+# seismic-foundry
+seismic-enclave = { git = "https://github.com/SeismicSystems/enclave.git", rev = "ac5e28dac1ee8ec0e3922b010e6da072d6e784aa" }


### PR DESCRIPTION
Bumped cargo-alloy to latest commit (which bumps upstream 1.3.1->1.4.1)
Was facing same issue as we recently had on cargo-alloy.
Solved it a bit differently (and imo more cleanly); see comment in cargo.toml.

Also drew this dependency diagram to figure out what's going on and why we need these patches in the first place.

<img width="2799" height="1338" alt="image" src="https://github.com/user-attachments/assets/8fb6fc4b-c0fa-44c1-942c-722f49499255" />
